### PR TITLE
Handle reAlign in animating state

### DIFF
--- a/src/Align.jsx
+++ b/src/Align.jsx
@@ -43,8 +43,7 @@ const Align = React.createClass({
     const props = this.props;
     // if parent ref not attached .... use document.getElementById
     if (!props.disabled) {
-      const source = ReactDOM.findDOMNode(this);
-      props.onAlign(source, align(source, props.target(), props.align));
+      this.align();
       if (props.monitorWindowResize) {
         this.startMonitorWindowResize();
       }
@@ -54,15 +53,13 @@ const Align = React.createClass({
   componentDidUpdate(prevProps) {
     let reAlign = false;
     const props = this.props;
-    let currentTarget;
 
     if (!props.disabled) {
       if (prevProps.disabled || prevProps.align !== props.align) {
         reAlign = true;
-        currentTarget = props.target();
       } else {
         const lastTarget = prevProps.target();
-        currentTarget = props.target();
+        const currentTarget = props.target();
         if (isWindow(lastTarget) && isWindow(currentTarget)) {
           reAlign = false;
         } else if (lastTarget !== currentTarget) {
@@ -72,8 +69,7 @@ const Align = React.createClass({
     }
 
     if (reAlign) {
-      const source = ReactDOM.findDOMNode(this);
-      props.onAlign(source, align(source, currentTarget, props.align));
+      this.align();
     }
 
     if (props.monitorWindowResize && !props.disabled) {
@@ -87,11 +83,25 @@ const Align = React.createClass({
     this.stopMonitorWindowResize();
   },
 
+  align() {
+    const props = this.props;
+    const source = ReactDOM.findDOMNode(this);
+    // Avoid calculating position when source is animating, common cases in rc-animate
+    // it will cause wrong align position
+    const originalAnimation = source.style.animation;
+    const originalTransition = source.style.transition;
+    source.style.animation = 'none';
+    source.style.transition = 'none';
+    props.onAlign(source, align(source, props.target(), props.align));
+    // restore these css properties
+    source.style.animation = originalAnimation;
+    source.style.transition = originalTransition;
+  },
+
   onWindowResize() {
     const props = this.props;
     if (!props.disabled) {
-      const source = ReactDOM.findDOMNode(this);
-      props.onAlign(source, align(source, props.target(), props.align));
+      this.align();
     }
   },
 


### PR DESCRIPTION
问题来源：https://github.com/ant-design/ant-design/issues/853

重现方式：rc-tooltip 的动画时间延长，在消失的过程中重新移入 trigger 上，触发展现，元素发生错位。

在浮层消失的动画过程中，触发展示，此时 rc-align 开始重新定位。由于元素此时正在动画过程中，`getBoundingClientRect` 计算得到的 source 节点的数据不准确，导致定位偏移。

这里在重定位时，重设了 animation 和 transition 这两个导致动画的样式属性。不是很优雅，但想不到更好的方案了。

