### PR TITLE
fix: defer callback to prevent triggering resizeobserver loop limit

### DIFF
--- a/src/util.ts
+++ b/src/util.ts
@@ -29,12 +29,16 @@ export function monitorResize(element: HTMLElement, callback: Function) {
   let prevHeight: number = null;
 
   function onResize([{ target }]: ResizeObserverEntry[]) {
+    if (!document.contains(target)) return;
     const { width, height } = target.getBoundingClientRect();
     const fixedWidth = Math.floor(width);
     const fixedHeight = Math.floor(height);
 
     if (prevWidth !== fixedWidth || prevHeight !== fixedHeight) {
-      callback({ width: fixedWidth, height: fixedHeight });
+      // https://webkit.org/blog/9997/resizeobserver-in-webkit/
+      requestAnimationFrame(() => {
+        callback({ width: fixedWidth, height: fixedHeight });
+      });
     }
 
     prevWidth = fixedWidth;


### PR DESCRIPTION
> If any changes are incurred during the callback, then layout happens again, but here, the system finds the shallowest at which depth a change occurred (measured in simple node depth from the root). Any changes that are related to something deeper down in the tree are delivered at once, while any that are not are queued up and delivered in the next frame, and an error message will be sent to the Web Inspector console: (ResizeObserver loop completed with undelivered notifications).
> <https://webkit.org/blog/9997/resizeobserver-in-webkit/>

the observed target might be removed during react re-render, which then triggers `ResizeObserver loop limit exceeded` or `ResizeObserver loop completed with undelivered notifications` error

One way to re-produce this issue is to visit pages with table and tooltip, such as <https://yuque.com/dashboard/docs>, hover the cursor onto the column header with sorter then an error about `ResizeObserver loop limit` is raised.