### PR TITLE
fix(examples): 1.修复examples文件夹中两处错误;

### DIFF
--- a/examples/follow.js
+++ b/examples/follow.js
@@ -9,7 +9,7 @@ const Demo = () => {
   const [visible, setVisible] = React.useState(true);
   const [svg, setSvg] = React.useState(false);
 
-  const sharedStyle: React.CSSProperties = {
+  const sharedStyle = {
     width,
     height,
     position: 'absolute',

--- a/examples/point.js
+++ b/examples/point.js
@@ -24,7 +24,7 @@ class Demo extends Component {
           Click this region please : )
         </div>
 
-        <Align ref={this.alignRef} target={this.state.point} align={align}>
+        <Align target={this.state.point} align={align}>
           <div
             style={{
               position: 'absolute',

--- a/src/interface.ts
+++ b/src/interface.ts
@@ -57,4 +57,4 @@ export interface TargetPoint {
   pageY?: number;
 }
 
-export type TargetType = (() => HTMLElement) | TargetPoint;
+export type TargetType = (() => HTMLElement | null) | TargetPoint;


### PR DESCRIPTION
1. ponti.js中  27行 <Align ref={this.alignRef} target={this.state.point} align={align}> 
  - 组件的 ref 的值 this.alignRef没有定义, 也没有使用; 删除

2. follow.js 第12行   const sharedStyle: React.CSSProperties = {
 -  在js文件中写ts语法, 需要删除