### PR TITLE
Replace a npm package `lodash` with its small analog `lodash.isequals` to reduce bundle size.

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "@babel/runtime": "^7.10.1",
     "classnames": "2.x",
     "dom-align": "^1.7.0",
-    "lodash": "^4.17.21",
+    "lodash.isequal": "^4.5.0",
     "rc-util": "^5.3.0",
     "resize-observer-polyfill": "^1.5.1"
   },

--- a/src/Align.tsx
+++ b/src/Align.tsx
@@ -8,7 +8,7 @@ import { composeRef } from 'rc-util/lib/ref';
 import isVisible from 'rc-util/lib/Dom/isVisible';
 import { alignElement, alignPoint } from 'dom-align';
 import addEventListener from 'rc-util/lib/Dom/addEventListener';
-import isEqual from 'lodash/isEqual';
+import isEqual from 'lodash.isequal';
 
 import { isSamePoint, restoreFocus, monitorResize } from './util';
 import type { AlignType, AlignResult, TargetType, TargetPoint } from './interface';


### PR DESCRIPTION
Replace a npm package `lodash`, from which a single function is used from whole lib, with its small analog `lodash.isequal` to reduce bundle size.