### PR TITLE
Fix the wrong position when source is inVisible.

### DIFF
--- a/src/Align.tsx
+++ b/src/Align.tsx
@@ -90,7 +90,7 @@ const Align: React.ForwardRefRenderFunction<RefAlign, AlignProps> = (
       const { activeElement } = document;
 
       // We only align when element is visible
-      if (element && isVisible(element)) {
+      if (element && isVisible(source) && isVisible(element)) {
         result = alignElement(source, element, latestAlign);
       } else if (point) {
         result = alignPoint(source, point, latestAlign);


### PR DESCRIPTION
If we keep calling fucntion alignElement when source was invisible, the position will be wrong